### PR TITLE
Created Sensor.py and sensor_object

### DIFF
--- a/CBlueApp.py
+++ b/CBlueApp.py
@@ -30,7 +30,7 @@ christopher.parrish@oregonstate.edu
 
 Last Edited By:
 Keana Kief (OSU)
-April 4th, 2023
+April 12th, 2023
 
 THINGS TO DO:
 Add comments
@@ -56,6 +56,7 @@ from Merge import Merge
 from Sbet import Sbet
 from Datum import Datum
 from Tpu import Tpu
+from Sensor import Sensor
 
 #Create a logging file named CBlue.log stored in the current working directory
 utils.CustomLogger(filename="CBlue.log")
@@ -143,7 +144,7 @@ class CBlueApp(tk.Tk):
         config = "cblue_configuration.json"
 
         with open(config, "w") as fp:
-            json.dump(self.controller_configuration, fp)
+            json.dump(self.controller_configuration, fp, indent=4)
 
     def show_docs(self):
         webbrowser.open(r"file://" + os.path.realpath("docs/html/index.html"), new=True)
@@ -413,6 +414,7 @@ class ControllerPanel(ttk.Frame):
             "HawkEye 4X 400m AGL",
             "HawkEye 4X 500m AGL",
             "HawkEye 4X 600m AGL",
+            # "PILLS"
         )
 
         ### Set up frame to hold dropdown menu ###
@@ -641,6 +643,9 @@ class ControllerPanel(ttk.Frame):
             self.controller.controller_configuration["sensor_model"]
         )
 
+        #Create a sensor object initialized to the user's selected sensor
+        sensor_object = Sensor(self.selected_sensor)
+
         multiprocess = self.controller.controller_configuration["multiprocess"]
 
         if multiprocess:
@@ -649,6 +654,12 @@ class ControllerPanel(ttk.Frame):
         else:
             cpu_process_info = ("singleprocess",)
 
+        #TODO: Create GUI object to hold wind_selection, self.wind_vals[wind_ind][1], kd_selection, self.kd_vals[kd_ind][1],
+        #           self.vdatum_region.get(), self.mcu, self.tpuOutput.directoryName, self.controller.controller_configuration["cBLUE_version"],
+        #           cpu_process_info, self.selected_sensor, self.controller.controller_configuration["water_surface_ellipsoid_height"],
+        #           self.controller.controller_configuration["error_type"], and self.csv_option.get(). 
+
+        #Initalize the tpu object
         tpu = Tpu(
             wind_selection,
             self.wind_vals[wind_ind][1],
@@ -658,13 +669,11 @@ class ControllerPanel(ttk.Frame):
             self.mcu,
             self.tpuOutput.directoryName,
             self.controller.controller_configuration["cBLUE_version"],
-            self.controller.controller_configuration["sensor_model"],
             cpu_process_info,
-            self.selected_sensor,
-            self.controller.controller_configuration["subaqueous_LUTs"],
             self.controller.controller_configuration["water_surface_ellipsoid_height"],
             self.controller.controller_configuration["error_type"],
             self.csv_option.get(),
+            sensor_object
         )
 
         las_files = [

--- a/Sensor.py
+++ b/Sensor.py
@@ -30,183 +30,56 @@ christopher.parrish@oregonstate.edu
 
 Last Edited:
 Keana Kief
-April 11th, 2023
+April 12th, 2023
 """
 
 import logging
+import os
+import json
 
 logger = logging.getLogger(__name__)
 
-#Current Sensors
-"""
-"Riegl VQ-880-G (0.7 mrad)": "RIEGL 0.7 mrad",
-"Riegl VQ-880-G (1.0 mrad)": "RIEGL 1.0 mrad",
-"Riegl VQ-880-G (1.5 mrad)": "RIEGL 1.5 mrad",
-"Riegl VQ-880-G (2.0 mrad)": "RIEGL 2.0 mrad",
-"Leica Chiroptera 4X (HawkEye 4X Shallow)": "CHIRO",
-"HawkEye 4X 400m AGL": "HAWK400",
-"HawkEye 4X 500m AGL": "HAWK500",
-"HawkEye 4X 600m AGL": "HAWK600",
-"""
+#Current Sensors:
+#   "Riegl VQ-880-G (0.7 mrad)"
+#   "Riegl VQ-880-G (1.0 mrad)"
+#   "Riegl VQ-880-G (1.5 mrad)"
+#   "Riegl VQ-880-G (2.0 mrad)"
+#   "Leica Chiroptera 4X (HawkEye 4X Shallow)"
+#   "HawkEye 4X 400m AGL"
+#   "HawkEye 4X 500m AGL"
+#   "HawkEye 4X 600m AGL"
 
-#TODO: Add PILLS TPU Model
-#TODO: Add sensor scan angle and range uncertainties
+#TODO: Add PILLS Sensor
 
 class Sensor: 
 
     def __init__(self, sensor_name):
-        """ Initalizes the sensor object based on the sensor name selected in CBlueApp.py.
+        #Initalizes the sensor object based on the sensor name selected in CBlueApp.py.
 
-        :param sensor_name: The name of the sensor model selected by the user in the GUI in CBlueApp.py
+        #:param sensor_name: The name of the sensor model selected by the user in the GUI in CBlueApp.py
 
-        :return: None
-        :rtype: None
-        """
-
+        #:return: None
+        #:rtype: None
+       
         #Assign the sensor name given to the sensor object
         self.name = sensor_name
-        
-        #Use the sensor name to initalize sensor values:
 
-        #If the sensor is Riegl VQ-880-G (0.7 mrad)
-        if (sensor_name=="Riegl VQ-880-G (0.7 mrad)"):
-            self.riegl_07_mrad()
-            logger.sensor(f"Initalized for Riegl VQ-880-G (0.7 mrad)")
+        #JSON file containing lidar sensor configurations for cBLUE
+        self.sensor_file = "lidar_sensors.json"
 
-        #If the sensor is Riegl VQ-880-G (1.0 mrad)
-        elif (sensor_name=="Riegl VQ-880-G (1.0 mrad)"):
-            self.riegl_10_mrad()
-            logger.sensor(f"Initalized for Riegl VQ-880-G (1.0 mrad)")
+        #Check if the lidar sensor config file exists
+        if os.path.isfile(self.sensor_file):
+            with open(self.sensor_file) as sf:
+                #If the file exists load the information into self.sensor_config
+                self.sensor_config = json.load(sf)
+        else:
+            logger.sensor("Sensor file doesn't exist")
 
-        #If the sensor is Riegl VQ-880-G (1.5 mrad)
-        elif (sensor_name=="Riegl VQ-880-G (1.5 mrad)"):
-            self.riegl_15_mrad()
-            logger.sensor(f"Initalized for Riegl VQ-880-G (1.5 mrad)")
-
-        #If the sensor is Riegl VQ-880-G (2.0 mrad)
-        elif (sensor_name=="Riegl VQ-880-G (2.0 mrad)"):
-            self.riegl_20_mrad()
-            logger.sensor(f"Initalized for Riegl VQ-880-G (2.0 mrad)")
-
-        #If the sensor is Leica Chiroptera 4X (HawkEye 4X Shallow)
-        elif (sensor_name=="Leica Chiroptera 4X (HawkEye 4X Shallow)"):
-            self.leica_chiroptera()
-            logger.sensor(f"Initalized for Leica Chiroptera 4X (HawkEye 4X Shallow)")
-
-        #If the sensor is HawkEye 4X 400m AGL
-        elif (sensor_name=="HawkEye 4X 400m AGL"):
-            self.hawkeye_400m()
-            logger.sensor(f"Initalized for HawkEye 4X 400m AGL")
-
-        #If the sensor is HawkEye 4X 500m AGL
-        elif (sensor_name=="HawkEye 4X 500m AGL"):
-            self.hawkeye_500m()
-            logger.sensor(f"Initalized for HawkEye 4X 500m AGL")
-
-        #If the sensor is HawkEye 4X 600m AGL
-        elif (sensor_name=="HawkEye 4X 600m AGL"):
-            self.hawkeye_600m()
-            logger.sensor(f"Initalized for HawkEye 4X 600m AGL")
-
-    
-    def riegl_07_mrad(self):
-        """ Initalizes the sensor object for Riegl VQ-880-G (0.7 mrad).
-        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
-
-        :return: None
-        :rtype: None
-        """
-        #The vertical Look Up Table used for modeling
-        self.vert_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad.csv"
-        #The horizontal Look Up Table used for modeling
-        self.horz_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad_hz.csv"
-
-
-    def riegl_10_mrad(self):
-        """ Initalizes the sensor object for Riegl VQ-880-G (1.0 mrad).
-        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
-
-        :return: None
-        :rtype: None
-        """
-        #The vertical Look Up Table used for modeling
-        self.vert_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad.csv"
-        #The horizontal Look Up Table used for modeling
-        self.horz_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad_hz.csv"
-
-
-    def riegl_15_mrad(self):
-        """ Initalizes the sensor object for Riegl VQ-880-G (1.5 mrad).
-        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
-
-        :return: None
-        :rtype: None
-        """
-        #The vertical Look Up Table used for modeling
-        self.vert_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad.csv"
-        #The horizontal Look Up Table used for modeling
-        self.horz_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad_hz.csv"
-
-
-    def riegl_20_mrad(self):
-        """ Initalizes the sensor object for Riegl VQ-880-G (2.0 mrad).
-        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
-
-        :return: None
-        :rtype: None
-        """
-        #The vertical Look Up Table used for modeling
-        self.vert_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad.csv"
-        #The horizontal Look Up Table used for modeling
-        self.horz_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad_hz.csv"
-
-
-    def leica_chiroptera(self):
-        """ Initalizes the sensor object for Leica Chiroptera 4X (HawkEye 4X Shallow). 
-        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
-
-        :return: None
-        :rtype: None
-        """
-        #The vertical Look Up Table used for modeling
-        self.vert_lut = "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_LUT_linear.csv"
-        #The horizontal Look Up Table used for modeling
-        self.horz_lut = "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_hz.csv"
-
-
-    def hawkeye_400m(self):
-        """ Initalizes the sensor object for HawkEye 4X 400m AGL. 
-        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
-
-        :return: None
-        :rtype: None
-        """
-        #The vertical Look Up Table used for modeling
-        self.vert_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad.csv"
-        #The horizontal Look Up Table used for modeling
-        self.horz_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad_hz.csv"
-
-
-    def hawkeye_500m(self):
-        """ Initalizes the sensor object for HawkEye 4X 500m AGL. 
-        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
-
-        :return: None
-        :rtype: None
-        """
-        #The vertical Look Up Table used for modeling
-        self.vert_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad.csv"
-        #The horizontal Look Up Table used for modeling
-        self.horz_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad_hz.csv"
-
-    def hawkeye_600m(self):
-        """ Initalizes the sensor object for HawkEye 4X 600m AGL. 
-        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
-
-        :return: None
-        :rtype: None
-        """
-        #The vertical Look Up Table used for modeling
-        self.vert_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad.csv"
-        #The horizontal Look Up Table used for modeling
-        self.horz_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad_hz.csv"
+        #The vertical look up table used for modeling
+        self.vert_lut = self.sensor_config[self.name]["subaqueous_LUTs"]["vertical"]
+        #The horizontal look up table used for modeling
+        self.horz_lut = self.sensor_config[self.name]["subaqueous_LUTs"]["horizontal"]
+        #Scan angle and range uncertainties
+        self.a_std_dev = self.sensor_config[self.name]["sensor_model"]["a_std_dev"]
+        self.b_std_dev = self.sensor_config[self.name]["sensor_model"]["b_std_dev"]
+        self.std_rho = self.sensor_config[self.name]["sensor_model"]["std_rho"]

--- a/Sensor.py
+++ b/Sensor.py
@@ -50,6 +50,7 @@ logger = logging.getLogger(__name__)
 """
 
 #TODO: Add PILLS TPU Model
+#TODO: Add sensor scan angle and range uncertainties
 
 class Sensor: 
 
@@ -209,40 +210,3 @@ class Sensor:
         self.vert_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad.csv"
         #The horizontal Look Up Table used for modeling
         self.horz_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad_hz.csv"
-
-
-
-#Lookup table file paths
-"""
-RIEGL 0.7 mrad:
-    "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad.csv"
-    "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad_hz.csv"
-
-RIEGL 1.0 mrad:
-    "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad.csv"
-    "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad_hz.csv"
-
-RIEGL 1.5 mrad:
-    "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad.csv"
-    "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad_hz.csv"
-    
-RIEGL 2.0 mrad:
-    "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad.csv"
-    "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad_hz.csv"
-    
-CHIRO:
-    "vertical": "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_LUT_linear.csv"
-    "horizontal": "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_hz.csv"
-
-HAWK400:
-    "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad.csv"
-    "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad_hz.csv"
-
-HAWK500:
-    "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad.csv"
-    "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad_hz.csv"
-
-HAWK600:
-    "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad.csv"
-    "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad_hz.csv"
-"""

--- a/Sensor.py
+++ b/Sensor.py
@@ -1,0 +1,248 @@
+"""
+cBLUE (comprehensive Bathymetric Lidar Uncertainty Estimator)
+Copyright (C) 2019
+Oregon State University (OSU)
+Center for Coastal and Ocean Mapping/Joint Hydrographic Center, University of New Hampshire (CCOM/JHC, UNH)
+NOAA Remote Sensing Division (NOAA RSD)
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Contact:
+Christopher Parrish, PhD
+School of Construction and Civil Engineering
+101 Kearney Hall
+Oregon State University
+Corvallis, OR  97331
+(541) 737-5688
+christopher.parrish@oregonstate.edu
+
+Last Edited:
+Keana Kief
+April 11th, 2023
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+#Current Sensors
+"""
+"Riegl VQ-880-G (0.7 mrad)": "RIEGL 0.7 mrad",
+"Riegl VQ-880-G (1.0 mrad)": "RIEGL 1.0 mrad",
+"Riegl VQ-880-G (1.5 mrad)": "RIEGL 1.5 mrad",
+"Riegl VQ-880-G (2.0 mrad)": "RIEGL 2.0 mrad",
+"Leica Chiroptera 4X (HawkEye 4X Shallow)": "CHIRO",
+"HawkEye 4X 400m AGL": "HAWK400",
+"HawkEye 4X 500m AGL": "HAWK500",
+"HawkEye 4X 600m AGL": "HAWK600",
+"""
+
+#TODO: Add PILLS TPU Model
+
+class Sensor: 
+
+    def __init__(self, sensor_name):
+        """ Initalizes the sensor object based on the sensor name selected in CBlueApp.py.
+
+        :param sensor_name: The name of the sensor model selected by the user in the GUI in CBlueApp.py
+
+        :return: None
+        :rtype: None
+        """
+
+        #Assign the sensor name given to the sensor object
+        self.name = sensor_name
+        
+        #Use the sensor name to initalize sensor values:
+
+        #If the sensor is Riegl VQ-880-G (0.7 mrad)
+        if (sensor_name=="Riegl VQ-880-G (0.7 mrad)"):
+            self.riegl_07_mrad()
+            logger.sensor(f"Initalized for Riegl VQ-880-G (0.7 mrad)")
+
+        #If the sensor is Riegl VQ-880-G (1.0 mrad)
+        elif (sensor_name=="Riegl VQ-880-G (1.0 mrad)"):
+            self.riegl_10_mrad()
+            logger.sensor(f"Initalized for Riegl VQ-880-G (1.0 mrad)")
+
+        #If the sensor is Riegl VQ-880-G (1.5 mrad)
+        elif (sensor_name=="Riegl VQ-880-G (1.5 mrad)"):
+            self.riegl_15_mrad()
+            logger.sensor(f"Initalized for Riegl VQ-880-G (1.5 mrad)")
+
+        #If the sensor is Riegl VQ-880-G (2.0 mrad)
+        elif (sensor_name=="Riegl VQ-880-G (2.0 mrad)"):
+            self.riegl_20_mrad()
+            logger.sensor(f"Initalized for Riegl VQ-880-G (2.0 mrad)")
+
+        #If the sensor is Leica Chiroptera 4X (HawkEye 4X Shallow)
+        elif (sensor_name=="Leica Chiroptera 4X (HawkEye 4X Shallow)"):
+            self.leica_chiroptera()
+            logger.sensor(f"Initalized for Leica Chiroptera 4X (HawkEye 4X Shallow)")
+
+        #If the sensor is HawkEye 4X 400m AGL
+        elif (sensor_name=="HawkEye 4X 400m AGL"):
+            self.hawkeye_400m()
+            logger.sensor(f"Initalized for HawkEye 4X 400m AGL")
+
+        #If the sensor is HawkEye 4X 500m AGL
+        elif (sensor_name=="HawkEye 4X 500m AGL"):
+            self.hawkeye_500m()
+            logger.sensor(f"Initalized for HawkEye 4X 500m AGL")
+
+        #If the sensor is HawkEye 4X 600m AGL
+        elif (sensor_name=="HawkEye 4X 600m AGL"):
+            self.hawkeye_600m()
+            logger.sensor(f"Initalized for HawkEye 4X 600m AGL")
+
+    
+    def riegl_07_mrad(self):
+        """ Initalizes the sensor object for Riegl VQ-880-G (0.7 mrad).
+        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
+
+        :return: None
+        :rtype: None
+        """
+        #The vertical Look Up Table used for modeling
+        self.vert_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad.csv"
+        #The horizontal Look Up Table used for modeling
+        self.horz_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad_hz.csv"
+
+
+    def riegl_10_mrad(self):
+        """ Initalizes the sensor object for Riegl VQ-880-G (1.0 mrad).
+        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
+
+        :return: None
+        :rtype: None
+        """
+        #The vertical Look Up Table used for modeling
+        self.vert_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad.csv"
+        #The horizontal Look Up Table used for modeling
+        self.horz_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad_hz.csv"
+
+
+    def riegl_15_mrad(self):
+        """ Initalizes the sensor object for Riegl VQ-880-G (1.5 mrad).
+        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
+
+        :return: None
+        :rtype: None
+        """
+        #The vertical Look Up Table used for modeling
+        self.vert_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad.csv"
+        #The horizontal Look Up Table used for modeling
+        self.horz_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad_hz.csv"
+
+
+    def riegl_20_mrad(self):
+        """ Initalizes the sensor object for Riegl VQ-880-G (2.0 mrad).
+        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
+
+        :return: None
+        :rtype: None
+        """
+        #The vertical Look Up Table used for modeling
+        self.vert_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad.csv"
+        #The horizontal Look Up Table used for modeling
+        self.horz_lut = "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad_hz.csv"
+
+
+    def leica_chiroptera(self):
+        """ Initalizes the sensor object for Leica Chiroptera 4X (HawkEye 4X Shallow). 
+        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
+
+        :return: None
+        :rtype: None
+        """
+        #The vertical Look Up Table used for modeling
+        self.vert_lut = "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_LUT_linear.csv"
+        #The horizontal Look Up Table used for modeling
+        self.horz_lut = "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_hz.csv"
+
+
+    def hawkeye_400m(self):
+        """ Initalizes the sensor object for HawkEye 4X 400m AGL. 
+        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
+
+        :return: None
+        :rtype: None
+        """
+        #The vertical Look Up Table used for modeling
+        self.vert_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad.csv"
+        #The horizontal Look Up Table used for modeling
+        self.horz_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad_hz.csv"
+
+
+    def hawkeye_500m(self):
+        """ Initalizes the sensor object for HawkEye 4X 500m AGL. 
+        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
+
+        :return: None
+        :rtype: None
+        """
+        #The vertical Look Up Table used for modeling
+        self.vert_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad.csv"
+        #The horizontal Look Up Table used for modeling
+        self.horz_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad_hz.csv"
+
+    def hawkeye_600m(self):
+        """ Initalizes the sensor object for HawkEye 4X 600m AGL. 
+        Sets the paths for the vertical (vert_lut) and horizontal (horz_lut) look up tables.
+
+        :return: None
+        :rtype: None
+        """
+        #The vertical Look Up Table used for modeling
+        self.vert_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad.csv"
+        #The horizontal Look Up Table used for modeling
+        self.horz_lut = "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad_hz.csv"
+
+
+
+#Lookup table file paths
+"""
+RIEGL 0.7 mrad:
+    "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad.csv"
+    "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad_hz.csv"
+
+RIEGL 1.0 mrad:
+    "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad.csv"
+    "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad_hz.csv"
+
+RIEGL 1.5 mrad:
+    "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad.csv"
+    "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad_hz.csv"
+    
+RIEGL 2.0 mrad:
+    "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad.csv"
+    "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad_hz.csv"
+    
+CHIRO:
+    "vertical": "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_LUT_linear.csv"
+    "horizontal": "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_hz.csv"
+
+HAWK400:
+    "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad.csv"
+    "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad_hz.csv"
+
+HAWK500:
+    "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad.csv"
+    "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad_hz.csv"
+
+HAWK600:
+    "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad.csv"
+    "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad_hz.csv"
+"""

--- a/Subaerial.py
+++ b/Subaerial.py
@@ -378,7 +378,7 @@ class SensorModel:
 
         num_coords, num_points = data.shape
         AMDE = np.mean(np.abs(data), axis=1)  # average mean distance error
-        RMSE = sqrt(sum(sum(np.square(data))) / num_points)  # root mean squares error
+        RMSE = np.sqrt(sum(sum(np.square(data))) / num_points)  # root mean squares error
 
         logger.subaerial(
             "Mean Difference:\n"

--- a/Subaqueous.py
+++ b/Subaqueous.py
@@ -100,24 +100,23 @@ class Subaqueous:
         :return: (fit_tvu, fit_thu) TVU and THU observation equation coefficients
         :rtype: (DataFrame, DataFrame)
         """
+        # wind_par values range from 0-20 kts, represented as integers 1-10.
+        # cBLUE gives users four options for Wind Speed:
+        #   Wind Speed: Calm-light air (0-2 kts) == [1]
+        #               Light Breeze (3-6 kts) == [2,3]
+        #               Gentle Breeze (7-10 kts) == [4,5]
+        #               Moderate Breeze (11-15 kts) == [6,7]
+        #               Fresh Breeze (16-20 kts) == [8, 9, 10]
 
         # Turbidity (kd_par) values range from 0.06-0.36 (m^-1) and are represented as integers 6-36.
         # cBLUE gives users five options for Turbidity:
-        #   kd: 0.06-0.10 m^-1 == [6-10]
-        #       0.11-0.17 m^-1 == [11-17]
-        #       0.18-0.25 m^-1 == [18-25]
-        #       0.26-0.32 m^-1 == [26-32]
-        #       0.33-0.36 m^-1 == [33-36]
+        #   kd: Clear (0.06-0.10 m^-1) == [6-10]
+        #       Clear-Moderate (0.11-0.17 m^-1) == [11-17]
+        #       Moderate (0.18-0.25 m^-1) == [18-25]
+        #       Moderate-High (0.26-0.32 m^-1) == [26-32]
+        #       High (0.33-0.36 m^-1) == [33-36]
 
-        # wind_par values range from 0-20 kts, represented as integers 1-10.
-        # cBLUE gives users four options for Wind Speed:
-        #   Wind Speed: 0-2 kts == [1]
-        #               3-6 kts == [2,3]
-        #               7-10 kts == [4,5]
-        #               11-15 kts == [6,7]
-        #               16-20 kts == [8, 9, 10]
-
-        # self.kd_par and self.wind_par are used to get the right indices for the lookup table.
+        # self.wind_par and self.kd_par are used to get the right indices for the lookup table.
         # The lookup table rows are ordered by the permutations of wind speed (low to high) with turbidity (low to high).
 
         # ex: row 0 represents observation equation coefficients for wind speed 1 and kd 6, 

--- a/Subaqueous.py
+++ b/Subaqueous.py
@@ -118,7 +118,7 @@ class Subaqueous:
             from Monte Carlo simulations for all given permutations of wind and kd from the vertical and horizontal lookup
             tables for the sensor used. 
 
-        :return: TVU and THU observation equation coefficients
+        :return: (fit_tvu, fit_thu) TVU and THU observation equation coefficients
         :rtype: (DataFrame, DataFrame)
         """
 

--- a/Subaqueous.py
+++ b/Subaqueous.py
@@ -28,15 +28,10 @@ Corvallis, OR  97331
 (541) 737-5688
 christopher.parrish@oregonstate.edu
 
-WHY WERE THERE 0 COMMENTS IN THIS WHOLE FILE!?!?! (AAAAARGGGH!!!)
-
 Last Edited:
-Keana Kief
-April 5th, 2023
+Keana Kief (OSU)
+April 12th, 2023
 """
-
-# -*- coding: utf-8 -*-
-# Oh, good. Thanks for the character encoding. That's what I really need to know...
 
 import logging
 import pandas as pd
@@ -49,33 +44,17 @@ class Subaqueous:
     To be used in conjunction with the associated
     """
 
-    def __init__(self, wind_par, kd_par, depth, sensor, subaqueous_luts):
-
-        sensor_aliases = {
-            "Riegl VQ-880-G (0.7 mrad)": "RIEGL 0.7 mrad",
-            "Riegl VQ-880-G (1.0 mrad)": "RIEGL 1.0 mrad",
-            "Riegl VQ-880-G (1.5 mrad)": "RIEGL 1.5 mrad",
-            "Riegl VQ-880-G (2.0 mrad)": "RIEGL 2.0 mrad",
-            "Leica Chiroptera 4X (HawkEye 4X Shallow)": "CHIRO",
-            "HawkEye 4X 400m AGL": "HAWK400",
-            "HawkEye 4X 500m AGL": "HAWK500",
-            "HawkEye 4X 600m AGL": "HAWK600",
-        }
+    def __init__(self, wind_par, kd_par, depth, sensor_object):
 
         self.wind_par = wind_par
         self.kd_par = kd_par
         self.depth = depth
-        self.sensor = sensor_aliases[sensor]
-
-        #The vertical Look Up Table used for modeling
-        self.vert_lut = subaqueous_luts[self.sensor]["vertical"]
-        #The horizontal Look Up Table used for modeling
-        self.horz_lut = subaqueous_luts[self.sensor]["horizontal"]
+        self.sensor_object = sensor_object
 
         logger.subaqueous(f"kd_par {self.kd_par}")
         logger.subaqueous(f"wind_par {self.wind_par}")
-        logger.subaqueous(self.vert_lut)
-        logger.subaqueous(self.horz_lut)
+        logger.subaqueous(f"vertical lut {self.sensor_object.vert_lut}")
+        logger.subaqueous(f"horizontal lut{self.sensor_object.horz_lut}")
 
     def fit_lut(self):
         """Called to begin the SubAqueous processing."""
@@ -149,25 +128,8 @@ class Subaqueous:
         indices = [31 * (w - 1) + k - 6 for w in self.wind_par for k in self.kd_par]
 
         # Read tables, select rows
-        fit_tvu = pd.read_csv(self.vert_lut, names=["a", "b"]).iloc[indices]
-        fit_thu = pd.read_csv(self.horz_lut, names=["a", "b"]).iloc[indices]
+        fit_tvu = pd.read_csv(self.sensor_object.vert_lut, names=["a", "b"]).iloc[indices]
+        fit_thu = pd.read_csv(self.sensor_object.horz_lut, names=["a", "b"]).iloc[indices]
 
         # Return TVU and THU observation equation coefficients DataFrames. 
         return fit_tvu, fit_thu
-
-    def get_subaqueous_meta_data(self):
-        """I haven't the patience to figure out why we need the MC ray tracing
-        metadata or if it's ever even used.
-        """
-        subaqueous_f = open(self.curr_lut, "r")
-        subaqueous_metadata = subaqueous_f.readline().split(",")
-        subaqueous_f.close()
-        subaqueous_metadata = {
-            k: v.strip() for (k, v) in [n.split(":") for n in subaqueous_metadata]
-        }
-        return subaqueous_metadata
-
-
-# Why? When are you gonna use this by itself? This will never me a __main__
-if __name__ == "__main__":
-    pass

--- a/Tpu.py
+++ b/Tpu.py
@@ -30,29 +30,23 @@ christopher.parrish@oregonstate.edu
 
 Last Edited By:
 Keana Kief (OSU)
-3/29/2023
+April 12th, 2023
 
 """
 
 import logging
-from pathlib import Path
 from pathos import logger
 import pathos.pools as pp
 import json
 import os
-import sys
 import laspy
 import numpy as np
-import numexpr as ne
 import pandas as pd
 import progressbar
 from tqdm import tqdm
-from collections import OrderedDict
 from Subaerial import Subaerial
 from Subaqueous import Subaqueous
 from Las import Las
-import datetime
-import cProfile
 
 logger = logging.getLogger(__name__)
 
@@ -85,21 +79,19 @@ class Tpu:
         vdatum_region_mcu,
         tpu_output,
         cblue_version,
-        sensor_model,
         cpu_process_info,
-        selected_sensor,
-        subaqueous_luts,
         water_surface_ellipsoid_height,
         error_type,
         csv_option,
+        sensor_object
     ):
 
         # TODO: refactor to pass the GUI object, not individual variables (with controller?)
         self.wind_selection = wind_selection
         self.wind_val = wind_val
 
-        logging.tpu(f"self.wind_selection (line 100) set to: {wind_selection}")
-        logging.tpu(f"self.wind_val (line 101) set to: {wind_val}")
+        logging.tpu(f"self.wind_selection (line 91) set to: {self.wind_selection}")
+        logging.tpu(f"self.wind_val (line 92) set to: {self.wind_val}")
 
         self.kd_selection = kd_selection
         self.kd_val = kd_val
@@ -107,13 +99,11 @@ class Tpu:
         self.vdatum_region_mcu = vdatum_region_mcu
         self.tpu_output = tpu_output
         self.cblue_version = cblue_version
-        self.sensor_model = sensor_model
         self.cpu_process_info = cpu_process_info
-        self.selected_sensor = selected_sensor
-        self.subaqueous_luts = subaqueous_luts
         self.water_surface_ellipsoid_height = water_surface_ellipsoid_height
         self.error_type = error_type
         self.csv_option = csv_option
+        self.sensor_object = sensor_object
 
         self.subaqu_lookup_params = None
         self.metadata = {}
@@ -164,7 +154,7 @@ class Tpu:
         # CREATE LAS OBJECT TO ACCESS INFORMATION IN LAS FILE
         las = Las(las_file)
 
-        diag_dfs = []
+        #diag_dfs = []
 
         if las.num_file_points:  # i.e., if las had data points
             logger.tpu(
@@ -217,13 +207,15 @@ class Tpu:
                             las.las_short_name
                         )
                     )
+
+                    #Initalize the subaqueous object
                     subaqu_obj = Subaqueous(
                         self.wind_val,
                         self.kd_val,
                         depth,
-                        self.selected_sensor,
-                        self.subaqueous_luts,
+                        self.sensor_object
                     )
+
                     subaqu_thu, subaqu_tvu = subaqu_obj.fit_lut()
 
                     vdatum_mcu = (
@@ -445,7 +437,7 @@ class Tpu:
                 "VDatum region": self.vdatum_region,
                 "VDatum region MCU": self.vdatum_region_mcu,
                 "flight line stats (min max mean stddev)": self.flight_line_stats,
-                "sensor model": self.sensor_model,
+                "sensor model": self.sensor_object.name,
                 "cBLUE version": self.cblue_version,
                 "cpu_processing_info": self.cpu_process_info,
                 "water_surface_ellipsoid_height": self.water_surface_ellipsoid_height,

--- a/anaconda_dir.txt
+++ b/anaconda_dir.txt
@@ -1,1 +1,0 @@
-C:\Users\Nick.Forfinski-Sarko\Anaconda3\ 

--- a/cblue_configuration.json
+++ b/cblue_configuration.json
@@ -1,1 +1,47 @@
-{"directories": {"tpu": "", "sbet": "", "las": ""}, "subaqueous_LUTs": {"RIEGL 0.7 mrad": {"vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad.csv", "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad_hz.csv"}, "RIEGL 1.0 mrad": {"vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad.csv", "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad_hz.csv"}, "RIEGL 1.5 mrad": {"vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad.csv", "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad_hz.csv"}, "RIEGL 2.0 mrad": {"vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad.csv", "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad_hz.csv"}, "CHIRO": {"vertical": "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_LUT_linear.csv", "horizontal": "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_hz.csv"}, "HAWK400": {"vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad.csv", "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad_hz.csv"}, "HAWK500": {"vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad.csv", "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad_hz.csv"}, "HAWK600": {"vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad.csv", "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad_hz.csv"}}, "multiprocess": "False", "number_cores": 4, "cBLUE_version": "v3.0", "sensor_model": "", "water_surface_ellipsoid_height": -38.09, "error_type": ""}
+{
+    "directories": {
+        "tpu": "",
+        "sbet": "",
+        "las": ""
+    },
+    "subaqueous_LUTs": {
+        "RIEGL 0.7 mrad": {
+            "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad.csv",
+            "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad_hz.csv"
+        },
+        "RIEGL 1.0 mrad": {
+            "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad.csv",
+            "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad_hz.csv"
+        },
+        "RIEGL 1.5 mrad": {
+            "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad.csv",
+            "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad_hz.csv"
+        },
+        "RIEGL 2.0 mrad": {
+            "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad.csv",
+            "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad_hz.csv"
+        },
+        "CHIRO": {
+            "vertical": "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_LUT_linear.csv",
+            "horizontal": "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_hz.csv"
+        },
+        "HAWK400": {
+            "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad.csv",
+            "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad_hz.csv"
+        },
+        "HAWK500": {
+            "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad.csv",
+            "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad_hz.csv"
+        },
+        "HAWK600": {
+            "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad.csv",
+            "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad_hz.csv"
+        }
+    },
+    "multiprocess": "False",
+    "number_cores": 4,
+    "cBLUE_version": "v3.0",
+    "sensor_model": "",
+    "water_surface_ellipsoid_height": -38.09,
+    "error_type": ""
+}

--- a/lidar_sensors.json
+++ b/lidar_sensors.json
@@ -1,26 +1,110 @@
 {
-  "Reigl VQ-880-G": {
-    "sensor_model": {
-      "sensor_type": "cBLUE (generic with polynomial error correction)",
-      "a_std_dev": 0.02,
-      "b_std_dev": 0.02,
-      "std_rho": 0.025
+    "Riegl VQ-880-G (0.7 mrad)": {
+        "sensor_model": {
+            "sensor_type": "cBLUE (generic with polynomial error correction)",
+            "a_std_dev": 0.02,
+            "b_std_dev": 0.02,
+            "std_rho": 0.025
+        },
+        "subaqueous_LUTs": {
+            "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad.csv",
+            "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad_hz.csv"
+        }
     },
-    "subaqueous_LUTs": {
-      "RIEGL": "./lookup_tables/Riegl_look_up_fit_HG0995_1sig.csv",
-      "ECKV": "./lookup_tables/ECKV_LUT_HG0995_1sig.csv"
-    }
-  },
-  "Leica Chiroptera 4X": {
-    "sensor_model": {
-      "sensor_type": "cBLUE (generic with polynomial error correction)",
-      "a_std_dev": 0.02,
-      "b_std_dev": 0.02,
-      "std_rho": 0.025
+    "Riegl VQ-880-G (1.0 mrad)": {
+        "sensor_model": {
+            "sensor_type": "cBLUE (generic with polynomial error correction)",
+            "a_std_dev": 0.02,
+            "b_std_dev": 0.02,
+            "std_rho": 0.025
+        },
+        "subaqueous_LUTs": {
+            "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad.csv",
+            "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad_hz.csv"
+        }
     },
-    "subaqueous_LUTs": {
-      "RIEGL": "",
-      "ECKV": ""
+    "Riegl VQ-880-G (1.5 mrad)": {
+        "sensor_model": {
+            "sensor_type": "cBLUE (generic with polynomial error correction)",
+            "a_std_dev": 0.02,
+            "b_std_dev": 0.02,
+            "std_rho": 0.025
+        },
+        "subaqueous_LUTs": {
+            "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad.csv",
+            "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad_hz.csv"
+        }
+    },
+    "Riegl VQ-880-G (2.0 mrad)": {
+        "sensor_model": {
+            "sensor_type": "cBLUE (generic with polynomial error correction)",
+            "a_std_dev": 0.02,
+            "b_std_dev": 0.02,
+            "std_rho": 0.025
+        },
+        "subaqueous_LUTs": {
+            "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad.csv",
+            "horizontal": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad_hz.csv"
+        }
+    },
+    "Leica Chiroptera 4X (HawkEye 4X Shallow)": {
+        "sensor_model": {
+            "sensor_type": "",
+            "a_std_dev": 0.25,
+            "b_std_dev": 0.25,
+            "std_rho": 0.020
+        },
+        "subaqueous_LUTs": {
+            "vertical": "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_LUT_linear.csv",
+            "horizontal": "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_hz.csv"
+        }
+    },
+    "HawkEye 4X 400m AGL": {
+        "sensor_model": {
+            "sensor_type": "",
+            "a_std_dev": 0.25,
+            "b_std_dev": 0.25,
+            "std_rho": 0.020
+        },
+        "subaqueous_LUTs": {
+            "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad.csv",
+            "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad_hz.csv"
+        }
+    },
+    "HawkEye 4X 500m AGL": {
+        "sensor_model": {
+            "sensor_type": "",
+            "a_std_dev": 0.25,
+            "b_std_dev": 0.25,
+            "std_rho": 0.020
+        },
+        "subaqueous_LUTs": {
+            "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad.csv",
+            "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad_hz.csv"
+        }
+    },
+    "HawkEye 4X 600m AGL": {
+        "sensor_model": {
+            "sensor_type": "",
+            "a_std_dev": 0.25,
+            "b_std_dev": 0.25,
+            "std_rho": 0.020
+        },
+        "subaqueous_LUTs": {
+            "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad.csv",
+            "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad_hz.csv"
+        }
+    },
+    "PILLS": {
+        "sensor_model": {
+            "sensor_type": "",
+            "a_std_dev": 0.015,
+            "b_std_dev": 0.00,
+            "std_rho": 0.033
+        },
+        "subaqueous_LUTs": {
+            "vertical": "",
+            "horizontal": ""
+        }
     }
-  }
 }

--- a/utils/custom_logger/custom_logger.py
+++ b/utils/custom_logger/custom_logger.py
@@ -44,6 +44,7 @@ class CustomLogger:
         "Merge": 27,
         "Datum": 28,
         "LasGrid": 29,
+        "Sensor": 31
     }
 
     def __init__(self, filename=None):

--- a/utils/custom_logger/custom_logger.py
+++ b/utils/custom_logger/custom_logger.py
@@ -2,6 +2,9 @@
 Summary:    This file contains the custom logging functionality.
 Author:     Forrest Corcoran
 Date:       5/20/2022
+
+Last Edited by: Keana Kief
+Last Edited: April 11th, 2023
 """
 import logging
 


### PR DESCRIPTION
Sensor.py creates a sensor object that will initialize to the sensor name selected by the user. This sensor object holds the sensor name, vertical look up tables, horizontal look up tables, and scan angle and range uncertainties. Sensor.py uses lidar_sensors.json to initialize sensor information. 

lidar_sensors.json has been populated with information for: 
- Riegl VQ-880-G (0.7 mrad)
- Riegl VQ-880-G (1.0 mrad)
- Riegl VQ-880-G (1.5 mrad)
- Riegl VQ-880-G (2.0 mrad)
- Leica Chiroptera 4X (HawkEye 4X Shallow)
- HawkEye 4X 400m AGL
- HawkEye 4X 500m AGL
- HawkEye 4X 600m AGL

lidar_sensors.json also has the skeleton for information for the PILLS sensor, but it needs to have the paths for the vertical and horizontal look up tables added.

CBlueApp.py has been modified to import Sensor and create a sensor_object (line 647) that is passed into tpu = Tpu() (lines 663-677).  CBlueApp.py has also been modified to pretty print the cblue_configuration.json when saved. Added "PILLS" sensor model option to the sensor model drop down option in the GUI. Commented the PILLS option out until fully implemented.

TPU.py has been modified to handle the sensor_object passed into the Tpu class. Unused import statements have also been removed. Passes the sensor_object into subaqu_obj = Subaqueous() (lines 212-217).

Subaqueous.py has been modified to handle the sensor_object passed into the Subaqueous class. Removed unused get_subaqueous_meta_data() function left over from scratch_Subaqueous.py. 

The custom logger has been modified to add a sensor logging level. 

Removed anaconda_dir.txt to resolve Issue #46 . 
