### PR TITLE
Update csv output

### DIFF
--- a/Las.py
+++ b/Las.py
@@ -28,6 +28,10 @@ Corvallis, OR  97331
 (541) 737-5688
 christopher.parrish@oregonstate.edu
 
+Last Edited By:
+Keana Kief (OSU)
+May 16th, 2023
+
 """
 import os
 import pandas as pd
@@ -86,18 +90,10 @@ class Las:
         :return: np.array, np.array, np.array, np.array
         """
 
-        scale_x = np.asarray(self.inFile.header.scales[0])
-        scale_y = np.asarray(self.inFile.header.scales[1])
-        scale_z = np.asarray(self.inFile.header.scales[2])
-
-        offset_x = np.asarray(self.inFile.header.offsets[0])
-        offset_y = np.asarray(self.inFile.header.offsets[1])
-        offset_z = np.asarray(self.inFile.header.offsets[2])
+        #xyz_to_decimal converts the x, y, z integer values to decimal values
+        x, y, z = self.xyz_to_decimal()
 
         t = self.points_to_process["gps_time"]
-        X = self.points_to_process["X"]
-        Y = self.points_to_process["Y"]
-        Z = self.points_to_process["Z"]
 
         if "classification" in self.points_to_process.array.dtype.names:
             c = self.points_to_process["classification"]
@@ -106,10 +102,6 @@ class Las:
         else:
             raise Exception("Unknown las version or missing classification attribute.")
 
-        x = ne.evaluate("X * scale_x + offset_x")
-        y = ne.evaluate("Y * scale_y + offset_y")
-        z = ne.evaluate("Z * scale_z + offset_z")
-
         self.t_argsort = t.argsort()
 
         xyztc = np.vstack([x, y, z, t, c]).T
@@ -117,8 +109,26 @@ class Las:
         flight_lines = self.points_to_process["pt_src_id"]
 
         return xyztc, self.t_argsort, flight_lines
+    
+    def xyz_to_decimal(self):
+        """The x, y, and z values in the las file are stored as integers.  The
+        scale and offset values in the las file header are used to convert
+        the integer values to decimal values with centimeter precision."""
 
+        scale_x = np.asarray(self.inFile.header.scales[0])
+        scale_y = np.asarray(self.inFile.header.scales[1])
+        scale_z = np.asarray(self.inFile.header.scales[2])
 
-if __name__ == "__main__":
-    pass
-# dummy comment
+        offset_x = np.asarray(self.inFile.header.offsets[0])
+        offset_y = np.asarray(self.inFile.header.offsets[1])
+        offset_z = np.asarray(self.inFile.header.offsets[2])
+
+        X = self.points_to_process["X"]
+        Y = self.points_to_process["Y"]
+        Z = self.points_to_process["Z"]
+
+        x = ne.evaluate("X * scale_x + offset_x")
+        y = ne.evaluate("Y * scale_y + offset_y")
+        z = ne.evaluate("Z * scale_z + offset_z")
+
+        return x, y, z

--- a/Las.py
+++ b/Las.py
@@ -90,8 +90,8 @@ class Las:
         :return: np.array, np.array, np.array, np.array
         """
 
-        #xyz_to_decimal converts the x, y, z integer values to decimal values
-        x, y, z = self.xyz_to_decimal()
+        #xyz_to_coordinate converts the x, y, z integer values to coordinate values
+        x, y, z = self.xyz_to_coordinate()
 
         t = self.points_to_process["gps_time"]
 
@@ -110,7 +110,7 @@ class Las:
 
         return xyztc, self.t_argsort, flight_lines
     
-    def xyz_to_decimal(self):
+    def xyz_to_coordinate(self):
         """The x, y, and z values in the las file are stored as integers.  The
         scale and offset values in the las file header are used to convert
         the integer values to decimal values with centimeter precision."""

--- a/Tpu.py
+++ b/Tpu.py
@@ -30,7 +30,7 @@ christopher.parrish@oregonstate.edu
 
 Last Edited By:
 Keana Kief (OSU)
-April 25th, 2023
+May 16th, 2023
 
 """
 
@@ -373,13 +373,18 @@ class Tpu:
             # get name of csv from las file
             out_csv_name = os.path.join(self.gui_object.output_directory, las.las_base_name) + "_TPU.csv"
 
+            csv_las = Las(out_las_name)
+
+            #xyz_to_decimal converts the x, y, z integer values to decimal values
+            x, y, z = csv_las.xyz_to_decimal()
+
             # Save relevant data to csv
             pd.DataFrame.from_dict(
                 {
                     "GPS Time": out_las.gps_time,
-                    "X": out_las.X,
-                    "Y": out_las.Y,
-                    "Z": out_las.Z,
+                    "X": x,
+                    "Y": y,
+                    "Z": z,
                     "THU": out_las.total_thu,
                     "TVU": out_las.total_tvu,
                     "Classification": out_las.classification,

--- a/Tpu.py
+++ b/Tpu.py
@@ -375,8 +375,8 @@ class Tpu:
 
             csv_las = Las(out_las_name)
 
-            #xyz_to_decimal converts the x, y, z integer values to decimal values
-            x, y, z = csv_las.xyz_to_decimal()
+            #xyz_to_coordinate converts the x, y, z integer values to decimal values
+            x, y, z = csv_las.xyz_to_coordinate()
 
             # Save relevant data to csv
             pd.DataFrame.from_dict(


### PR DESCRIPTION
The csv option printed the X, Y, and Z point record from the las file to the csv file instead of the actual X, Y, and Z coordinate. 

Using the [ASPRS LAS Specification](https://www.asprs.org/wp-content/uploads/2019/07/LAS_1_4_r15.pdf): 
> to compute a given X coordinate from the point record, the point record X is multiplied by the X scale factor and then added to the X offset.
> 
> 𝑋𝑐𝑜𝑜𝑟𝑑𝑖𝑛𝑎𝑡𝑒 = (𝑋𝑟𝑒𝑐𝑜𝑟𝑑 * 𝑋𝑠𝑐𝑎𝑙𝑒) + 𝑋𝑜𝑓𝑓𝑠𝑒𝑡   (1)
> 𝑌𝑐𝑜𝑜𝑟𝑑𝑖𝑛𝑎𝑡𝑒 = (𝑌𝑟𝑒𝑐𝑜𝑟𝑑 * 𝑌𝑠𝑐𝑎𝑙𝑒) + 𝑌𝑜𝑓𝑓𝑠𝑒𝑡   (2)
> 𝑍𝑐𝑜𝑜𝑟𝑑𝑖𝑛𝑎𝑡𝑒 = (𝑍𝑟𝑒𝑐𝑜𝑟𝑑 * 𝑍𝑠𝑐𝑎𝑙𝑒) + 𝑍𝑜𝑓𝑓𝑠𝑒𝑡   (3)

Las.py has been modified to move the XYZ coordinate conversion to it's own function: xyz_to_coordinate(). 

xyz_to_coordinate() is used in Tpu.py to convert the point record to coordinates, and print the coordinate values to the csv file.