### PR TITLE
Multi beam refactoring

### DIFF
--- a/Las.py
+++ b/Las.py
@@ -30,7 +30,7 @@ christopher.parrish@oregonstate.edu
 
 Last Edited By:
 Keana Kief (OSU)
-May 30th, 2023
+July 25th, 2023
 
 
 """
@@ -81,7 +81,7 @@ class Las:
         # pandas' unique faster than numpy's ?
         return pd.unique(self.points_to_process["pt_src_id"])
 
-    def get_flight_line(self, sensor_name):
+    def get_flight_line(self, sensor_type):
         """retrieves the x, y, z, and timestamp data from the las data points
 
         The x, y, and z values in the las file are stored as integers.  The
@@ -106,13 +106,13 @@ class Las:
 
         self.t_argsort = t.argsort()
 
-        # Check if this is the PILLS sensor
-        if(sensor_name == "PILLS"):
+        # Check if this is a multi beam sensor
+        if(sensor_type == "multi"):
             #Get the fan angle and multiply it by 0.006 to convert to degrees
             fan_angle = self.inFile.scan_angle*0.006
             #Add xyztcf to an array together
             xyztcf = np.vstack([x, y, z, t, c, fan_angle]).T
-            # logger.las(f"{sensor_name} Fan Angle: {fan_angle}")
+            # logger.las(f"{sensor_type} Fan Angle: {fan_angle}")
         else:
             #Fan angle is not used by the other sensors
             #Add xyztc to an array together

--- a/Merge.py
+++ b/Merge.py
@@ -30,7 +30,7 @@ christopher.parrish@oregonstate.edu
 
 Last Edited By:
 Keana Kief (OSU)
-June 20th, 2023
+July 25th, 2023
 
 """
 
@@ -118,11 +118,13 @@ class Merge:
         #TODO: Only for testing if merging data fails, the las data might have the wrong time format.
         #       In the future turn this into a function that checks what the las time format is and 
         #       convert it into adjusted standard gps time.
-        # if(sensor_object.name == "PILLS"):
-        #     #Convert UTC time to Adjusted Standard GPS time (with leap seconds adjustment for data on or after Jan 1st 2017)
-        #     # fl_las_data[:, 3] = fl_las_data[:, 3] - 1e9 + 18
-        #     #Convert standard gps time to Adjusted Standard GPS time
-        #     fl_las_data[:, 3] = fl_las_data[:, 3] - 1e9
+        # Check if this is a multi beam sensor, like PILLS/RAMMS
+        # if(sensor_object.type == "multi"):
+        # Use the UTC time conversion or the standard gps time conversion, not both 
+            # Convert UTC time to Adjusted Standard GPS time (with leap seconds adjustment for data on or after Jan 1st 2017)
+            # fl_las_data[:, 3] = fl_las_data[:, 3] - 1e9 + 18
+            # Convert standard gps time to Adjusted Standard GPS time
+            # fl_las_data[:, 3] = fl_las_data[:, 3] - 1e9
 
         # match sbet and las dfs based on timestamps
         idx = np.searchsorted(sbet_data[:, 0], fl_las_data[:, 3])
@@ -187,8 +189,8 @@ class Merge:
 
             masked_fan_angle = []
 
-            # If this is the PILLS sensor, use the mask on the fan angle array 
-            if(sensor_object.name == "PILLS"):
+            # If this is a multi beam sensor, use the mask on the fan angle array 
+            if(sensor_object.type == "multi"):
                 masked_fan_angle = fl_las_data[:, 5][mask]
                 #Take the absolute value of the fan angle
                 masked_fan_angle = np.absolute(masked_fan_angle)

--- a/Sbet.py
+++ b/Sbet.py
@@ -30,7 +30,7 @@ christopher.parrish@oregonstate.edu
 
 Last Edited By:
 Keana Kief (OSU)
-May 16th, 2023
+July 25th, 2023
 
 """
 
@@ -191,12 +191,14 @@ class Sbet:
             logger.sbet("-" * 50)
             logger.sbet("{}...".format(os.path.split(sbet)[-1]))
             sbet_date = self.get_sbet_date(sbet)
+
             # If this is the PILLS sensor, pre-process the sbet data
-            if(self.sensor_name == "PILLS"):
-                logger.sbet("PILLS Sensor, pre-processing sbet file")
+            if(self.sensor_name == "PILLS or RAMMS"):
+                logger.sbet("PILLS or RAMMS Sensor, pre-processing sbet file")
                 self.preprocess_pills_sbet(sbet, modified_sbet_file)
                 # Reassign the SBET file name to the modified file
                 sbet = modified_sbet_file
+
             sbet_df = pd.read_csv(
                 sbet,
                 skip_blank_lines=True,

--- a/Sensor.py
+++ b/Sensor.py
@@ -39,18 +39,6 @@ import json
 
 logger = logging.getLogger(__name__)
 
-#Current Sensors:
-#   "Riegl VQ-880-G (0.7 mrad)"
-#   "Riegl VQ-880-G (1.0 mrad)"
-#   "Riegl VQ-880-G (1.5 mrad)"
-#   "Riegl VQ-880-G (2.0 mrad)"
-#   "Leica Chiroptera 4X (HawkEye 4X Shallow)"
-#   "HawkEye 4X 400m AGL"
-#   "HawkEye 4X 500m AGL"
-#   "HawkEye 4X 600m AGL"
-
-#TODO: Add PILLS Sensor
-
 class Sensor: 
 
     def __init__(self, sensor_name):

--- a/Sensor.py
+++ b/Sensor.py
@@ -29,8 +29,8 @@ Corvallis, OR  97331
 christopher.parrish@oregonstate.edu
 
 Last Edited:
-Keana Kief
-April 12th, 2023
+Keana Kief (OSU)
+July 25th, 2023
 """
 
 import logging
@@ -75,6 +75,8 @@ class Sensor:
         else:
             logger.sensor("Sensor file doesn't exist")
 
+        #The type of sensor: single or multi beam
+        self.type = self.sensor_config[self.name]["sensor_model"]["type"]
         #The vertical look up table used for modeling
         self.vert_lut = self.sensor_config[self.name]["subaqueous_LUTs"]["vertical"]
         #The horizontal look up table used for modeling

--- a/Subaqueous.py
+++ b/Subaqueous.py
@@ -213,7 +213,7 @@ class Subaqueous:
         #               3: ("Moderate Breeze (11-15 kts)", [6, 7]),
         #               4: ("Fresh Breeze (16-20 kts)", [8, 9, 10])
 
-        # self.gui_object.wind_ind and self.gui_object.kd_ind are used to get the right sheet from the PILLS lookup table.
+        # self.gui_object.wind_ind and self.gui_object.kd_ind are used to get the right sheet from the lookup table.
         # The excel sheets are ordered by the permutations of turbidity (low to high) with wind speed (low to high).
 
         # ex: sheet 0 represents fan angle observation equation coefficients for kd selection 0 and wind speed selection 0, 

--- a/Subaqueous.py
+++ b/Subaqueous.py
@@ -30,7 +30,7 @@ christopher.parrish@oregonstate.edu
 
 Last Edited:
 Keana Kief (OSU)
-May 31th, 2023
+July 25th, 2023
 """
 
 import logging
@@ -130,14 +130,14 @@ class Subaqueous:
         # Return averaged TVU and THU observation equation coefficient DataFrames. 
         return mean_fit_tvu, mean_fit_thu
     
-    def pills_fit_lut(self, masked_fan_angle):
-        """Called to begin the SubAqueous processing for the PILLS sensor"""
+    def multi_beam_fit_lut(self, masked_fan_angle):
+        """Called to begin the SubAqueous processing for multi beam sensors"""
     
         # tvu values below 0.03 are considered erroneous
         min_tvu = 0.03
 
         # query coefficients from look up tables
-        fit_tvu, fit_thu = self.pills_model_process()
+        fit_tvu, fit_thu = self.multi_beam_model_process()
 
         # a_h := horizontal linear coeffs
         # b_h := horizontal linear offsets
@@ -188,7 +188,7 @@ class Subaqueous:
 
         return np.asarray(res_thu), np.asarray(res_tvu)
     
-    def pills_model_process(self):
+    def multi_beam_model_process(self):
         """Retrieves the page of TVU and THU observation equation coefficients for all fan angles for the given combination
             of wind and kd. TVU and THU observation equation coefficients are based on the linear regression of 
             precalculated uncertainties from Monte Carlo simulations  
@@ -224,14 +224,14 @@ class Subaqueous:
         sheet = (5 * self.gui_object.kd_ind) + self.gui_object.wind_ind
 
         logger.subaqueous(f"kd_ind: {self.gui_object.kd_ind}, wind_ind: {self.gui_object.wind_ind}")
-        logger.subaqueous(f"PILLS look up table sheet number: {sheet}")
+        logger.subaqueous(f"Multi beam look up table sheet number: {sheet}")
 
         # Read look up tables, select rows
         fit_tvu = pd.read_excel(self.sensor_object.vert_lut, sheet_name=sheet, header=None, names=["a", "b"])
         fit_thu = pd.read_excel(self.sensor_object.horz_lut, sheet_name=sheet, header=None, names=["a", "b"])
 
-        # logger.subaqueous(f"PILLS fit_tvu: {fit_tvu}")
-        # logger.subaqueous(f"PILLS fit_thu: {fit_thu}")
+        # logger.subaqueous(f"Multi beam fit_tvu: {fit_tvu}")
+        # logger.subaqueous(f"Multi beam fit_thu: {fit_thu}")
 
         # Return DataFrames of TVU and THU observation equation coefficients for each fan angle. 
         return fit_tvu, fit_thu

--- a/Tpu.py
+++ b/Tpu.py
@@ -422,14 +422,15 @@ class Tpu:
                 "sensor model": self.sensor_object.name,
                 "cBLUE version": self.gui_object.cblue_version,
                 "cpu_processing_info": self.gui_object.cpu_process_info,
-                "water_surface_ellipsoid_height": self.gui_object.water_surface_ellipsoid_height
+                "water_surface_ellipsoid_height": self.gui_object.water_surface_ellipsoid_height,
+                "Error type": self.gui_object.error_type
             }
         )
 
         try:
             # self.metadata['flight line stats'].update(self.flight_line_stats)  # flight line metadata
             with open(
-                os.path.join(self.gui_object.output_directory, "{}.json".format(las.las_base_name)), "w"
+                os.path.join(self.gui_object.output_directory, "{}.json".format(las.las_base_name)), "w", encoding="utf-8"
             ) as outfile:
 
                 json.dump(self.metadata, outfile, indent=1, ensure_ascii=False)

--- a/Tpu.py
+++ b/Tpu.py
@@ -30,7 +30,7 @@ christopher.parrish@oregonstate.edu
 
 Last Edited By:
 Keana Kief (OSU)
-May 31th, 2023
+July 25th, 2023
 
 """
 
@@ -131,7 +131,7 @@ class Tpu:
             )
             logger.tpu("flight lines {}".format(las.unq_flight_lines))
 
-            unsorted_las_xyztcf, t_argsort, flight_lines = las.get_flight_line(self.sensor_object.name)
+            unsorted_las_xyztcf, t_argsort, flight_lines = las.get_flight_line(self.sensor_object.type)
 
             self.flight_line_stats = {}  # reset flight line stats dict
             for fl in las.unq_flight_lines:
@@ -187,9 +187,9 @@ class Tpu:
                         self.sensor_object
                     )
 
-                    if(self.sensor_object.name == "PILLS"):
-                        #PILLS Sensor: Sending to pills_fit_lut() 
-                        subaqu_thu, subaqu_tvu = subaqu_obj.pills_fit_lut(masked_fan_angle) 
+                    if(self.sensor_object.type == "multi"):
+                        #Multi beam sensor: Sending to multi_beam_fit_lut() 
+                        subaqu_thu, subaqu_tvu = subaqu_obj.multi_beam_fit_lut(masked_fan_angle) 
                     
                     else:
                         #Not PILLS Sensor: Sending to fit_lut() 

--- a/Tpu.py
+++ b/Tpu.py
@@ -192,7 +192,7 @@ class Tpu:
                         subaqu_thu, subaqu_tvu = subaqu_obj.multi_beam_fit_lut(masked_fan_angle) 
                     
                     else:
-                        #Not PILLS Sensor: Sending to fit_lut() 
+                        #Single beam Sensor: Sending to fit_lut() 
                         subaqu_thu, subaqu_tvu = subaqu_obj.fit_lut()     
 
                     vdatum_mcu = (

--- a/lidar_sensors.json
+++ b/lidar_sensors.json
@@ -3,7 +3,8 @@
         "sensor_model": {
             "a_std_dev": 0.02,
             "b_std_dev": 0.02,
-            "std_rho": 0.025
+            "std_rho": 0.025,
+            "type": "single"
         },
         "subaqueous_LUTs": {
             "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_0.7_mrad.csv",
@@ -14,7 +15,8 @@
         "sensor_model": {
             "a_std_dev": 0.02,
             "b_std_dev": 0.02,
-            "std_rho": 0.025
+            "std_rho": 0.025,
+            "type": "single"
         },
         "subaqueous_LUTs": {
             "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1_mrad.csv",
@@ -25,7 +27,8 @@
         "sensor_model": {
             "a_std_dev": 0.02,
             "b_std_dev": 0.02,
-            "std_rho": 0.025
+            "std_rho": 0.025,
+            "type": "single"
         },
         "subaqueous_LUTs": {
             "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_1.5_mrad.csv",
@@ -36,7 +39,8 @@
         "sensor_model": {
             "a_std_dev": 0.02,
             "b_std_dev": 0.02,
-            "std_rho": 0.025
+            "std_rho": 0.025,
+            "type": "single"
         },
         "subaqueous_LUTs": {
             "vertical": "./lookup_tables/RieglVQ880_LUTs/ReiglVQ880G_600_AGL_2_mrad.csv",
@@ -47,7 +51,8 @@
         "sensor_model": {
             "a_std_dev": 0.025,
             "b_std_dev": 0.025,
-            "std_rho": 0.020
+            "std_rho": 0.020,
+            "type": "single"
         },
         "subaqueous_LUTs": {
             "vertical": "./lookup_tables/Chiroptera_4X_400_AGL_4pt75_mrad_LUT_linear.csv",
@@ -58,7 +63,8 @@
         "sensor_model": {
             "a_std_dev": 0.025,
             "b_std_dev": 0.025,
-            "std_rho": 0.020
+            "std_rho": 0.020,
+            "type": "single"
         },
         "subaqueous_LUTs": {
             "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_400_AGL_8_mrad.csv",
@@ -69,7 +75,8 @@
         "sensor_model": {
             "a_std_dev": 0.025,
             "b_std_dev": 0.025,
-            "std_rho": 0.020
+            "std_rho": 0.020,
+            "type": "single"
         },
         "subaqueous_LUTs": {
             "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_500_AGL_8_mrad.csv",
@@ -80,18 +87,20 @@
         "sensor_model": {
             "a_std_dev": 0.025,
             "b_std_dev": 0.025,
-            "std_rho": 0.020
+            "std_rho": 0.020,
+            "type": "single"
         },
         "subaqueous_LUTs": {
             "vertical": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad.csv",
             "horizontal": "./lookup_tables/Hawkeye_LUTs/HawkEye4X_Deep_600_AGL_8_mrad_hz.csv"
         }
     },
-    "PILLS": {
+    "PILLS or RAMMS": {
         "sensor_model": {
             "a_std_dev": 0.015,
             "b_std_dev": 0.00,
-            "std_rho": 0.033
+            "std_rho": 0.033,
+            "type": "multi"
         },
         "subaqueous_LUTs": {
             "vertical": "./lookup_tables/PILLS_Lookup_Results_Vertical.xlsx",


### PR DESCRIPTION
Refactored code to reference multi beam sensors instead of specifically the PILLS sensor. This will make it easier to add new multi beam sensors in the future. 

The lidar_sensors.json now has a "type" field that notes if the sensor is single or multi beam. The sensor type is stored in the sensor class. Checks for if the sensor name is PILLS were replaced by checks if the type is multi. 

The name for the PILLS sensor has been updated to "PILLS or RAMMS", as the RAMMS sensor has the same TPU calculations as PILLS. 

Sbet.py still checks if the sensor name is "PILLS or RAMMS", as the preprocess_pills_sbet is a unique function for those sensors.